### PR TITLE
Fixed the debug issue with docker compose

### DIFF
--- a/Prototype/Dockerfile
+++ b/Prototype/Dockerfile
@@ -38,3 +38,4 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "Prototype.dll"]
+RUN dotnet restore

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,26 @@
+services:
+  frontend:
+    build:
+      target: dev
+    volumes:
+      - ./Prototype/ClientApp:/app
+      - /app/node_modules
+    environment:
+      - CHOKIDAR_USE_POLLING=true
+      - BROWSER=none
+
+  backend:
+    build:
+      target: dev
+    volumes:
+      - ./Prototype:/src/Prototype:cached
+      - ~/.nuget/packages:/root/.nuget/packages
+    environment:
+      - DOTNET_USE_POLLING_FILE_WATCHER=1
+      - ASPNETCORE_ENVIRONMENT=Development
+    networks:
+      - prototype_default
+
+networks:
+  prototype_default:
+    external: true


### PR DESCRIPTION
*** THIS WAS TESTED AND WORKS FOR RIDER, OTHER IDE's HAVE NOT BEEN TESTED AND AM UNSURE IF THIS FIX WILL RESOLVE IT***

What caused this issue?

When performing a docker based debug for the project, the ide creates a separate docker container that is not on the same network as the compose container. By attaching the debug into the compose container, there should now be an established connection to the local db. You should no longer get this issue:

Microsoft.Data.SqlClient.SqlException (0x80131904): A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: TCP Provider, error: 40 - Could not open a connection to SQL Server)
   at 
   
Ensure that riders debug configuration has a compose file for the compose and compose override yaml and has no services set and is attached to none